### PR TITLE
Reduce click listeners of home screen's navigation to details

### DIFF
--- a/app/src/main/java/com/skorudzhiev/cookery/ui/navigation/CookeryNavigation.kt
+++ b/app/src/main/java/com/skorudzhiev/cookery/ui/navigation/CookeryNavigation.kt
@@ -37,9 +37,7 @@ fun NavGraphBuilder.addHomeGraph(
 ) {
     composable(HomeSections.CATEGORIES.route) { from ->
         Categories(
-            openMealDetails = { id, type -> onItemSelected(id, type, from) },
-            openAreaDetails = { id, type -> onItemSelected(id, type, from) },
-            openCategoryDetails = { id, type -> onItemSelected(id, type, from) }
+            openDetailsScreen = { id, type -> onItemSelected(id, type, from) }
         )
     }
     composable(HomeSections.SEARCH.route) { from ->

--- a/common-ui-compose/src/main/java/com/cookery/common/compose/components/CategoryTypes.kt
+++ b/common-ui-compose/src/main/java/com/cookery/common/compose/components/CategoryTypes.kt
@@ -50,7 +50,7 @@ internal fun Areas(
 @Composable
 internal fun RandomizedMeals(
     categoryMeals: List<CategoryDetails>,
-    openMealDetails: (String, String) -> Unit,
+    openDetailsScreen: (String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyRow(
@@ -62,7 +62,7 @@ internal fun RandomizedMeals(
         items(categoryMeals) { meal ->
             RandomizedMealItem(
                 meal = meal,
-                onMealClicked = openMealDetails
+                openDetailsScreen = openDetailsScreen
             )
         }
     }
@@ -71,7 +71,7 @@ internal fun RandomizedMeals(
 @Composable
 internal fun RandomizedMealItem(
     meal: CategoryDetails,
-    onMealClicked: (String, String) -> Unit,
+    openDetailsScreen: (String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val mealType = stringResource(R.string.category_type_popular)
@@ -80,7 +80,7 @@ internal fun RandomizedMealItem(
         modifier = modifier
             .clickable(
                 onClick = {
-                    onMealClicked(
+                    openDetailsScreen(
                         meal.mealId,
                         mealType
                     )
@@ -109,7 +109,7 @@ internal fun HighlightedCategories(
         items(categories) { category ->
             HighlightedCategoryItem(
                 category = category,
-                onMealClicked = openCategoryDetails
+                openDetailsScreen = openCategoryDetails
             )
         }
     }
@@ -118,7 +118,7 @@ internal fun HighlightedCategories(
 @Composable
 internal fun HighlightedCategoryItem(
     category: Category,
-    onMealClicked: (String, String) -> Unit,
+    openDetailsScreen: (String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val mealType = stringResource(R.string.category_type_popular)
@@ -127,7 +127,7 @@ internal fun HighlightedCategoryItem(
         modifier = modifier
             .clickable(
                 onClick = {
-                    onMealClicked(category.categoryId, mealType)
+                    openDetailsScreen(category.categoryId, mealType)
                 }
             )
             .fillMaxSize()
@@ -142,7 +142,7 @@ internal fun HighlightedCategoryItem(
 @Composable
 private fun Categories(
     meals: List<Category>,
-    onMealClicked: (String) -> Unit,
+    openDetailsScreen: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyRow(
@@ -153,7 +153,7 @@ private fun Categories(
         items(meals) { category ->
             CategoryItem(
                 category = category,
-                onMealClicked = onMealClicked
+                openDetailsScreen = openDetailsScreen
             )
         }
     }
@@ -162,7 +162,7 @@ private fun Categories(
 @Composable
 internal fun CategoryItem(
     category: Category,
-    onMealClicked: (String) -> Unit,
+    openDetailsScreen: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Surface(
@@ -175,7 +175,7 @@ internal fun CategoryItem(
         Column(
             horizontalAlignment = CenterHorizontally,
             modifier = Modifier
-                .clickable(onClick = { onMealClicked(category.categoryId) })
+                .clickable(onClick = { openDetailsScreen(category.categoryId) })
                 .padding(8.dp)
         ) {
             category.categoryImage?.let {

--- a/common-ui-compose/src/main/java/com/cookery/common/compose/components/LazyLists.kt
+++ b/common-ui-compose/src/main/java/com/cookery/common/compose/components/LazyLists.kt
@@ -30,9 +30,7 @@ fun <T> CollectionWithHeader(
     items: List<T>,
     title: String,
     refreshing: Boolean,
-    openMealDetails: (String, String) -> Unit,
-    openCategoryDetails: (String, String) -> Unit,
-    openAreaDetails: (String, String) -> Unit,
+    openDetailsScreen: (String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
 
@@ -51,9 +49,7 @@ fun <T> CollectionWithHeader(
         HandleCategoryTypes(
             items = items,
             title = title,
-            openMealDetails = openMealDetails,
-            openCategoryDetails = openCategoryDetails,
-            openAreaDetails = openAreaDetails
+            openDetailsScreen = openDetailsScreen
         )
         // todo: check for internet connection, or else
     }
@@ -64,9 +60,7 @@ fun <T> CollectionWithHeader(
 internal fun <T> HandleCategoryTypes(
     items: List<T>,
     title: String,
-    openMealDetails: (String, String) -> Unit,
-    openCategoryDetails: (String, String) -> Unit,
-    openAreaDetails: (String, String) -> Unit,
+    openDetailsScreen: (String, String) -> Unit
 ) {
     val popular = stringResource(R.string.category_type_popular)
     val categories = stringResource(R.string.category_type_all_categories)
@@ -77,19 +71,19 @@ internal fun <T> HandleCategoryTypes(
         when (title) {
             popular -> RandomizedMeals(
                 categoryMeals = items as List<CategoryDetails>,
-                openMealDetails = openMealDetails
+                openDetailsScreen = openDetailsScreen
             )
             categories -> HighlightedCategories(
                 categories = items as List<Category>,
-                openCategoryDetails = openCategoryDetails
+                openCategoryDetails = openDetailsScreen
             )
             recommended -> RandomizedMeals(
                 categoryMeals = items as List<CategoryDetails>,
-                openMealDetails = openMealDetails
+                openDetailsScreen = openDetailsScreen
             )
             areas -> Areas(
                 areas = items as List<Area>,
-                openAreaDetails = openAreaDetails
+                openAreaDetails = openDetailsScreen
             )
         }
     }
@@ -135,9 +129,7 @@ internal fun Header(
 fun <T> Collection(
     items: List<T>,
     title: String,
-    openMealDetails: (String, String) -> Unit,
-    openCategoryDetails: (String, String) -> Unit,
-    openAreaDetails: (String, String) -> Unit,
+    openDetailsScreen: (String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier) {
@@ -146,9 +138,7 @@ fun <T> Collection(
         HandleCategoryTypes(
             items = items,
             title = title,
-            openMealDetails = openMealDetails,
-            openCategoryDetails = openCategoryDetails,
-            openAreaDetails = openAreaDetails
+            openDetailsScreen = openDetailsScreen
         )
     }
 }

--- a/ui-categories/src/main/java/app/cookery/home/categories/Categories.kt
+++ b/ui-categories/src/main/java/app/cookery/home/categories/Categories.kt
@@ -26,9 +26,7 @@ import kotlinx.coroutines.flow.collect
 
 @Composable
 fun Categories(
-    openMealDetails: (String, String) -> Unit,
-    openCategoryDetails: (String, String) -> Unit,
-    openAreaDetails: (String, String) -> Unit
+    openDetailsScreen: (String, String) -> Unit
 ) {
     val viewModel: CategoriesViewModel = hiltViewModel()
     val viewState by rememberFlowWithLifecycle(viewModel.state)
@@ -39,9 +37,7 @@ fun Categories(
     Categories(
         state = viewState,
         refresh = { viewModel.submitAction(CategoriesAction.RefreshAction) },
-        openMealDetails = openMealDetails,
-        openCategoryDetails = openCategoryDetails,
-        openAreaDetails = openAreaDetails
+        openDetails = openDetailsScreen
     )
 }
 
@@ -67,9 +63,7 @@ internal fun InitializeAppData(viewModel: CategoriesViewModel) {
 internal fun Categories(
     state: CategoriesViewState,
     refresh: () -> Unit,
-    openMealDetails: (String, String) -> Unit,
-    openCategoryDetails: (String, String) -> Unit,
-    openAreaDetails: (String, String) -> Unit,
+    openDetails: (String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Surface(modifier = modifier.fillMaxSize()) {
@@ -96,9 +90,7 @@ internal fun Categories(
                         items = state.popularMeals,
                         title = stringResource(R.string.category_type_popular),
                         refreshing = state.randomCategoriesRefreshing,
-                        openMealDetails = openMealDetails,
-                        openCategoryDetails = openCategoryDetails,
-                        openAreaDetails = openAreaDetails
+                        openDetailsScreen = openDetails,
                     )
                 }
 
@@ -107,9 +99,7 @@ internal fun Categories(
                         items = state.mealCategories,
                         title = stringResource(R.string.category_type_all_categories),
                         refreshing = state.categoriesRefreshing,
-                        openMealDetails = openMealDetails,
-                        openCategoryDetails = openCategoryDetails,
-                        openAreaDetails = openAreaDetails
+                        openDetailsScreen = openDetails
                     )
                 }
 
@@ -118,9 +108,7 @@ internal fun Categories(
                         items = state.recommendedMeals,
                         title = stringResource(R.string.category_type_recommended),
                         refreshing = state.randomAreasRefreshing,
-                        openMealDetails = openMealDetails,
-                        openCategoryDetails = openCategoryDetails,
-                        openAreaDetails = openAreaDetails
+                        openDetailsScreen = openDetails
                     )
                 }
 
@@ -129,9 +117,7 @@ internal fun Categories(
                         items = state.areaMeals.take(14),
                         title = stringResource(R.string.category_type_areas),
                         refreshing = state.areasRefreshing,
-                        openMealDetails = openMealDetails,
-                        openCategoryDetails = openCategoryDetails,
-                        openAreaDetails = openAreaDetails
+                        openDetailsScreen = openDetails
                     )
                 }
 
@@ -139,9 +125,7 @@ internal fun Categories(
                     Collection(
                         items = state.areaMeals.takeLast(13),
                         title = stringResource(R.string.category_type_areas),
-                        openMealDetails = openMealDetails,
-                        openCategoryDetails = openCategoryDetails,
-                        openAreaDetails = openAreaDetails
+                        openDetailsScreen = openDetails
                     )
                 }
             }


### PR DESCRIPTION
With the current change we reduce the click listeners of home screen to one, since the additional parameter introduced in the click listener provides information about the type of item, which is sufficient to determine the desired  intent.