### PR TITLE
Fix layouts on the detail screens to consider the app system bars

### DIFF
--- a/ui-details/src/main/java/app/cookery/details/area/AreaDetails.kt
+++ b/ui-details/src/main/java/app/cookery/details/area/AreaDetails.kt
@@ -40,6 +40,8 @@ import com.cookery.common.compose.modifiers.Layout
 import com.cookery.common.compose.modifiers.bodyWidth
 import com.cookery.common.compose.modifiers.copy
 import com.cookery.common.compose.rememberFlowWithLifecycle
+import com.google.accompanist.insets.LocalWindowInsets
+import com.google.accompanist.insets.rememberInsetsPaddingValues
 
 @Composable
 fun AreaDetails(
@@ -110,7 +112,17 @@ private fun AreaDetails(
             )
         },
     ) { contentPadding ->
-        Surface(modifier = Modifier.bodyWidth()) {
+        Surface(
+            modifier = Modifier
+                .bodyWidth()
+                .padding(
+                    rememberInsetsPaddingValues(
+                        insets = LocalWindowInsets.current.systemBars,
+                        applyBottom = true,
+                        applyTop = false,
+                    )
+                )
+        ) {
             AreaDetails(
                 areaDetails = viewState.areaWithCategoryDetails,
                 listState = listState,

--- a/ui-details/src/main/java/app/cookery/details/category/CategoryDetails.kt
+++ b/ui-details/src/main/java/app/cookery/details/category/CategoryDetails.kt
@@ -44,6 +44,8 @@ import com.cookery.common.compose.modifiers.Layout
 import com.cookery.common.compose.modifiers.bodyWidth
 import com.cookery.common.compose.modifiers.copy
 import com.cookery.common.compose.rememberFlowWithLifecycle
+import com.google.accompanist.insets.LocalWindowInsets
+import com.google.accompanist.insets.rememberInsetsPaddingValues
 
 @Composable
 fun CategoryDetails(
@@ -112,7 +114,17 @@ private fun CategoryDetails(
             )
         },
     ) { contentPadding ->
-        Surface(modifier = Modifier.bodyWidth()) {
+        Surface(
+            modifier = Modifier
+                .bodyWidth()
+                .padding(
+                    rememberInsetsPaddingValues(
+                        insets = LocalWindowInsets.current.systemBars,
+                        applyBottom = true,
+                        applyTop = false,
+                    )
+                )
+        ) {
             CategoryDetails(
                 categoryDetails = viewState.categoryWithCategoryDetails,
                 listState = listState,

--- a/ui-details/src/main/java/app/cookery/details/meal/MealDetails.kt
+++ b/ui-details/src/main/java/app/cookery/details/meal/MealDetails.kt
@@ -64,7 +64,9 @@ import com.cookery.common.compose.theme.CookeryLightColors
 import com.cookery.common.compose.theme.CookeryTypography
 import com.cookery.common.compose.theme.youTubeButtonColor
 import com.google.accompanist.flowlayout.FlowRow
+import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.navigationBarsPadding
+import com.google.accompanist.insets.rememberInsetsPaddingValues
 import com.google.accompanist.insets.statusBarsPadding
 import kotlin.math.max
 import kotlin.math.min
@@ -112,7 +114,13 @@ private fun MealDetails(
     Box(
         Modifier
             .fillMaxSize()
-            .padding(bottom = 56.dp)
+            .padding(
+                rememberInsetsPaddingValues(
+                    insets = LocalWindowInsets.current.systemBars,
+                    applyBottom = true,
+                    applyTop = false,
+                )
+            )
     ) {
         Spacer(
             modifier = Modifier


### PR DESCRIPTION
This PR fixes an issue with screen content that was overlapping with the app system bars. The introduced fix makes use of local windows insets to fix the encountered issue.